### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.4.17
+FROM mongo:7.0.3
 
 LABEL maintainer="Nnadozie Okeke <dozie@fronte.io>"
 LABEL repository="https://github.com/VNDRMKT/mongodump-s3-backup"


### PR DESCRIPTION
Our Mongo Atlas DB version was updated to v7. This updates the Docker image used so that the mongodump cli tool used matched v7.